### PR TITLE
chore : 한국시간 설정

### DIFF
--- a/myproject/myproject/settings.py
+++ b/myproject/myproject/settings.py
@@ -108,11 +108,11 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Asia/Seoul'
 
 USE_I18N = True
 
-USE_TZ = True
+USE_TZ = False
 
 
 # Static files (CSS, JavaScript, Images)


### PR DESCRIPTION
댓글 및 게시글 작성 시 한국시간이 뜨도록 `settings.py`에서
- `TIME_ZONE`을 `'Asia/Seoul' 변경
- `USE_TZ`를 `False`로 설정