### PR TITLE
feat : 카카오 로그인

### DIFF
--- a/myproject/myproject/pipeline.py
+++ b/myproject/myproject/pipeline.py
@@ -11,7 +11,12 @@ def create_custom_user(strategy, details, backend, user=None, *args, **kwargs):
         return {'user': user}
 
     email = details.get('email')
-    nickname = details.get('nickname') or details.get('name') or '네이버사용자'
+    if backend.name == 'naver':
+        nickname = details.get('nickname') or '네이버사용자'
+    elif backend.name == 'kakao':
+        nickname = details.get('nickname') or '카카오사용자'
+    else:
+        nickname = '소셜사용자'
 
     user_id = kwargs.get('uid') or email or strategy.session_get('user_id_fallback')
 

--- a/myproject/myproject/settings.py
+++ b/myproject/myproject/settings.py
@@ -146,9 +146,14 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = BASE_DIR / 'media'
 
 AUTHENTICATION_BACKENDS = [
+    'social_core.backends.kakao.KakaoOAuth2', 
     'social_core.backends.naver.NaverOAuth2',  
     'django.contrib.auth.backends.ModelBackend',
 ]
+
+SOCIAL_AUTH_KAKAO_KEY = os.environ.get('SOCIAL_AUTH_KAKAO_KEY')
+SOCIAL_AUTH_KAKAO_REDIRECT_URI = 'http://127.0.0.1:8000/auth/complete/kakao/'
+SOCIAL_AUTH_KAKAO_SCOPE = ['profile_nickname']
 
 SOCIAL_AUTH_NAVER_KEY = 'xgzdJuOuHlzgq6RTVLnX'
 SOCIAL_AUTH_NAVER_SECRET = 'I4IQPaEGv9'

--- a/myproject/user/templates/login.html
+++ b/myproject/user/templates/login.html
@@ -37,5 +37,11 @@
     <img src="https://static.nid.naver.com/oauth/small_g_in.PNG" alt="네이버 로그인 버튼" width="140">
     </a>
 
+    <hr>
+    <a href="{% url 'social:begin' 'kakao' %}">
+    <img src="https://developers.kakao.com/tool/resource/static/img/button/login/full/ko/kakao_login_medium_narrow.png" 
+         alt="카카오 로그인 버튼" width="180">
+    </a>
+
 </body>
 </html>


### PR DESCRIPTION
- KakaoOAuth2 기반 카카오 소셜 로그인 기능 구현 (이메일 항목은 Kakao 비즈니스 인증 필요)
- 로그인 시 사용자 닉네임을 '카카오사용자', '네이버사용자' 등으로 자동 설정
- .env 파일을 통한 REST API 키 관리

